### PR TITLE
Provides CIB Fastlane (SensibilityTestbed/custominstallerbuilder#2)

### DIFF
--- a/html/static/css/base.css
+++ b/html/static/css/base.css
@@ -241,6 +241,10 @@ button:active, .button:active {
   display: none;
 }
 
+.center {
+  text-align: center;
+}
+
 .round_shadow {
   -webkit-box-shadow: 0 1px 2px #eee;
   -moz-box-shadow: 0 1px 2px #eee;

--- a/html/static/css/download_installers.css
+++ b/html/static/css/download_installers.css
@@ -13,26 +13,32 @@
   Installer Builder.
 *****************************************************************/
 
-#url {
-  margin: 2em 0 2em 5%;
-}
 
-#url span {
-  border: 1px solid #f7e7ad;
-  
-  background-color: #fdf3d0;
-  margin: 0.4em;
+
+.share-url {
+  display: inline-block;
   padding: 0.4em;
-  
+  margin: 0.4em;
+
+  background-color: #fdf3d0;
+  text-decoration: none;
+
+  border: 1px solid #f7e7ad;
   -webkit-border-radius: 2px;
   -moz-border-radius: 2px;
   border-radius: 2px;
+
+  /* Break line on small screen */
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  -ms-word-break: break-all;
+  word-break: break-all;
 }
 
-#url a {
-  text-decoration: none;
-  color: inherit;
+#qrcode img {
+  margin: 2em auto;
 }
+
 
 table#downloads {
   margin-left: 5%;

--- a/html/static/css/download_keys.css
+++ b/html/static/css/download_keys.css
@@ -16,3 +16,16 @@
 table {
   margin-left: 5%;
 }
+
+.button.key {
+  width: 230px;
+}
+.button.key:before,
+.button.key:after {
+  content: "";
+  display: inline-block;
+  width: 2em;
+}
+.button.key.checked:before {
+  content: "\2713";
+}

--- a/html/static/js/keys.js
+++ b/html/static/js/keys.js
@@ -32,19 +32,14 @@ $(document).ready(function () {
 function addCheck(button) {
   /*****************************************************************
   <Purpose>
-    Adds a check mark to the button if one is not already there.
+    Adds class "checked" to  button (passed as argument) to display
+    a lovely unicode check mark in front of the button text using
+    the :before pseudo element
   <Arguments>
     button:
       A button DOM element.
-  <Side Effects>
-    Puts a lovely unicode check mark in front of the button text.
   <Returns>
     None.
   *****************************************************************/
-  
-  if ($(button).text().search(new RegExp(/[\u2713]/i)) != -1) {
-    return;
-  }
-  
-  $(button).html('&#10003; ' + $(button).html());
+  $(button).addClass('checked');
 }

--- a/html/templates/download_installers.html
+++ b/html/templates/download_installers.html
@@ -4,6 +4,12 @@
 <!-- Custom -->
 <link rel="stylesheet" href="{{ MEDIA_URL }}css/download_installers.css" />
 <script type="text/javascript" src="{{ MEDIA_URL}}js/qrcode.min.js"></script>
+
+{# comment: On the fast lane we have installers and keys on one page #}
+{% if fast_lane %}
+<link rel="stylesheet" href="{{ MEDIA_URL }}css/download_keys.css" />
+<script type="text/javascript" src="{{ MEDIA_URL }}js/keys.js"></script>
+{% endif %}
 {% endblock %}
 
 {% block content %}
@@ -31,6 +37,24 @@ new QRCode(document.getElementById("qrcode"), {
 });
     </script></div>
 </div>
+
+
+{% if fast_lane %}
+<div class="section">
+  <h2>Download user keys</h2>
+  <p>For your reference, the Custom Installer Builder has generated ZIP archives of cryptographic keys associated with your installer. Once your browsing session expires, you cannot access these keys again.</p>
+
+  <table>
+    <tr id="private_keys">
+      <td><a id="download_private_keys" class="button key {% if keys_downloaded.private %}checked{% endif %}" href="{% url 'download-keys' build_id=build_id key_type='private' %}">Download private keys</a></td>
+    </tr>
+    <tr id="public_keys">
+      <td><a id="download_public_keys" class="button key {% if keys_downloaded.public %}checked{% endif %}" href="{% url 'download-keys' build_id=build_id key_type='public' %}">Download public keys</a></td>
+    </tr>
+  </table>
+
+</div>
+{% endif %} {# comment: endif fast_lane #}
 
 <div class="section">
   <h2>Download installers</h2>

--- a/html/templates/download_installers.html
+++ b/html/templates/download_installers.html
@@ -15,11 +15,13 @@
 {% block content %}
 <!-- Un-Django-comment the block below to style the page differently depending on whether the person that built this installer sees it (`user_built==True`), or the person comes in via a shared link. We currently disable this to always show a QR code for this page. -->
 {% comment %}
-<div class="section">
+<div class="section center">
   {% if user_built %}
     <h2>Your installers are ready!</h2>
     <p>Bookmark this page to come back later, or share this URL with others:</p>
-    <div id="url"><span class="round_shadow"><a href="{{ share_url }}">{{ share_url }}</a></span> Right click on the URL to copy the address.</div>
+    <div id="url"><span class="round_shadow">
+      <a href="{{ share_url }}">{{ share_url }}</a>
+    </span> Right click on the URL to copy the address.</div>
   {% else %}
     <h2>Thanks for contributing!</h2>
     <p>The installers below have been customized by a Seattle user. By running these installers, 10% of your computing resources will be donated to an experiment being run by that user.</p>
@@ -27,15 +29,17 @@
 </div>
 {% endcomment %}
 
-<div class="section">
-    <div id="url"><span class="round_shadow"><a href="{{ share_url }}">{{ share_url }}</a></span> Right-click on the URL to copy the address, or scan the QR code below.<p>
-    <div id="qrcode"></div><script type="text/javascript">
-new QRCode(document.getElementById("qrcode"), {
-    text: "{{ share_url }}",
-    width: 128,
-    height: 128
-});
-    </script></div>
+<div class="section center">
+  <a class="share-url round_shadow" href="{{ share_url }}">{{ share_url }}</a>
+  <div>Right-click on the URL to copy the address, or scan the QR code below.</div>
+  <div id="qrcode"></div>
+  <script type="text/javascript">
+    new QRCode(document.getElementById("qrcode"), {
+        text: "{{ share_url }}",
+        width: 128,
+        height: 128
+    });
+  </script>
 </div>
 
 

--- a/html/templates/download_keys.html
+++ b/html/templates/download_keys.html
@@ -16,12 +16,12 @@
         
     {% if has_private_keys %}
   	<tr id="private_keys">
-  	  <td><a id="download_private_keys" class="button" href="{% url 'download-keys' build_id=build_id key_type='private' %}">{% if keys_downloaded.private %}&#10003; {% endif %}Download private keys</a></td><td>You must download an archive of the private keys that were generated for new users.</td>
+      <td><a id="download_private_keys" class="button key {% if keys_downloaded.private %}checked{% endif %}" href="{% url 'download-keys' build_id=build_id key_type='private' %}">Download private keys</a></td><td>You must download an archive of the private keys that were generated for new users.</td>
   	</tr>
     {% endif %}
   
     <tr id="public_keys" {% if has_private_keys and not keys_downloaded.private %}class="hidden"{% endif %}>
-      <td><a id="download_public_keys" class="button" href="{% url 'download-keys' build_id=build_id key_type='public' %}">{% if keys_downloaded.public %}&#10003; {% endif %}Download public keys</a></td><td>It is strongly recommended that you download an archive of the public keys of all users.</td>
+      <td><a id="download_public_keys" class="button key {% if keys_downloaded.public %}checked{% endif %}" href="{% url 'download-keys' build_id=build_id key_type='public' %}">Download public keys</a></td><td>It is strongly recommended that you download an archive of the public keys of all users.</td>
     </tr>
   
   </table>

--- a/html/urls.py
+++ b/html/urls.py
@@ -27,6 +27,7 @@ urlpatterns = patterns('custominstallerbuilder.html.views',
   #   Example: http://example.com/custominstallerbuilder/
   #        or  http://example.com/custominstallerbuilder/ajax/build/
   url(r'^$', 'builder_page', name='builder'),
+  url(r'^fastlane/$', 'fastlane_page', name='fastlane_page'),
   url(r'^ajax/build/$', 'build_installers', name='ajax-build'),
   url(r'^ajax/save/$', 'save_state', name='ajax-save'),
   url(r'^ajax/restore/$', 'restore_state', name='ajax-restore'),

--- a/html/views.py
+++ b/html/views.py
@@ -530,7 +530,7 @@ def fastlane_page(request):
   """
 
   try:
-    build_result = False
+    existing_build_result = False
 
     # We have to check if the user already has a build result in his session
     # and make sure it's a fastlane build, i.e.
@@ -538,17 +538,17 @@ def fastlane_page(request):
     if 'build_results' in request.session.keys():
       for val in request.session['build_results'].values():
         if isinstance(val, dict) and val.get("fast_lane_build"):
-          build_result = val
+          existing_build_result = val
           break
     else:
       # This dict will only be saved if the build succeeds
       request.session['build_results'] = {}
 
 
-    if build_result:
+    if existing_build_result:
       # There is no need to build again, let's serve what's already there
-      build_id = build_result.get('build_id')
-      keys_downloaded = build_result.get('keys_downloaded', dict())
+      build_id = existing_build_result.get('build_id')
+      keys_downloaded = existing_build_result.get('keys_downloaded', dict())
 
       # The manager helps us to find the files stored to disk
       manager = BuildManager(build_id=build_id)
@@ -571,7 +571,7 @@ def fastlane_page(request):
       # Use build manager to create and store vesselinfo
       # and create cryptographic key pair (only stored in memory)
       manager = BuildManager(vessel_list=vessels, user_data=users)
-      build_results = manager.prepare()
+      new_fastlane_build_results = manager.prepare()
 
       # These are needed in the HTML template to render the proper links
       # to the keys and installer
@@ -586,11 +586,11 @@ def fastlane_page(request):
       # in the same session
       # also hides breadcrumbs when serving shared (w/o key links) fastlane 
       # download page
-      build_results["fast_lane_build"] = True
+      new_fastlane_build_results["fast_lane_build"] = True
 
       # download_installer and download_keys views get the build_results
       # from the session to serve the correct files
-      request.session['build_results'][build_id] = build_results
+      request.session['build_results'][build_id] = new_fastlane_build_results
       request.session.save()
 
   except:

--- a/html/views.py
+++ b/html/views.py
@@ -487,7 +487,11 @@ def download_installers_page(request, build_id):
     if build_id in request.session['build_results']:
       step = 'installers'
       user_built = True
-    
+
+      # If we serve a fast_lane_build we don't show the breadcrumbs
+      if 'fast_lane_build' in request.session['build_results'][build_id]:
+        step = False
+
   return render_to_response('download_installers.html',
     {
       'build_id': build_id,
@@ -508,7 +512,10 @@ def fastlane_page(request):
   <Purpose>
     Renders a key and installer download page for a
     default user-built seattle build, i.e.:
-      One vessel, no users, owner name: `default`
+      One 80 per-cent vessel, one owner/user
+
+      Note: 
+      owner/user-name can be set in settings.FASTLANE_USER_NAME
   <Arguments>
     request:
       A Django request.
@@ -521,8 +528,6 @@ def fastlane_page(request):
   <Returns>
     A Django response.
   """
-
-  fastlane_user_name = u'default'
 
   try:
     if 'build_results' in request.session.keys() and \
@@ -549,11 +554,11 @@ def fastlane_page(request):
       # The user is here for the first time
       # Create basic installation setup (1 owner, 1 vessel, no users)
       users = {
-        fastlane_user_name: {u'public_key': None}
+        settings.FASTLANE_USER_NAME: {u'public_key': None}
         }
       vessels = [
         {
-          u'owner': fastlane_user_name, 
+          u'owner': settings.FASTLANE_USER_NAME, 
           u'percentage': 80, 
           u'users': []
         }

--- a/html/views.py
+++ b/html/views.py
@@ -542,7 +542,7 @@ def fastlane_page(request):
           break
     else:
       # This dict will only be saved if the build succeeds
-      request.session['build_result'] = {}
+      request.session['build_results'] = {}
 
 
     if build_result:

--- a/html/views.py
+++ b/html/views.py
@@ -578,6 +578,10 @@ def fastlane_page(request):
       # The keys are new so they cannot have been downloaded
       keys_downloaded = False
 
+      # This prevents collision when using interactive CIB and fastlane CIB
+      # in the same session
+      # Also hides breadcrumbs when serving "shared" (w/o key links) fastlane 
+      # download page
       build_results["fast_lane_build"] = True
 
       # download_installer/download_keys views get the build_results
@@ -592,10 +596,16 @@ def fastlane_page(request):
     return ErrorResponse('Unknown error occured while' + \
                          ' trying to build the installers.')
 
+  # Builds share_url by using view URLreversing and the request object
+  share_url = request.build_absolute_uri(reverse('download-installers-page', 
+      args=[build_id]))
+
+
   return render_to_response('download_installers.html', {
       'fast_lane': True,
       'build_id': build_id,
       'installers': installer_links,
+      'share_url': share_url,
       'keys_downloaded': keys_downloaded,
     }, context_instance=RequestContext(request))
 

--- a/settings_base.py
+++ b/settings_base.py
@@ -130,3 +130,5 @@ CUSTOM_INSTALLER_URL = PROJECT_URL + 'static/installers/'
 # During testing, you may want to use Django's built-in static file server.
 SERVE_STATIC = False
 STATIC_BASE = 'static/'
+
+FASTLANE_USER_NAME = 'user'


### PR DESCRIPTION
This PR implements a CIB fastlane as requested in SensibilityTestbed/custominstallerbuilder#2, i.e.

It adds a combined CIB download page for a Seattle **installer** and the according **key pair** with one *default* owner, one vessel (80%) and no additional users, which could also be achieved by following the [interactive CIB manual](https://sensibilitytestbed.com/projects/project/wiki/setup#Buildinganinstaller 
) usually presented to Sensibility/RepyV2 hackathon participants.

Additionally it adds minor CSS enhancements


*Note: SensibilityTestbed/custominstallerbuilder is way behind its upstream in SeattleTestsbed, therefore we PR here.*
