### PR TITLE
Upgrade to at least Django 1.8 Fix - #6

### DIFF
--- a/html/urls.py
+++ b/html/urls.py
@@ -13,44 +13,49 @@
   Custom Installer Builder.
 """
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 import custominstallerbuilder.common.constants as constants
+import custominstallerbuilder.html.views as views
 
 
-urlpatterns = patterns('custominstallerbuilder.html.views',
+urlpatterns = [
 
   # Builder interface.
-  
+
   # These patterns match the string between ^ and $ against the end portion of
   # the URL.
   #   Example: http://example.com/custominstallerbuilder/
   #        or  http://example.com/custominstallerbuilder/ajax/build/
-  url(r'^$', 'builder_page', name='builder'),
-  url(r'^fastlane/$', 'fastlane_page', name='fastlane_page'),
-  url(r'^ajax/build/$', 'build_installers', name='ajax-build'),
-  url(r'^ajax/save/$', 'save_state', name='ajax-save'),
-  url(r'^ajax/restore/$', 'restore_state', name='ajax-restore'),
-  url(r'^ajax/reset/$', 'reset_state', name='ajax-reset'),
-  url(r'^ajax/add-user/$', 'add_user', name='ajax-add-user'),
+  url(r'^$', views.builder_page, name='builder'),
+  url(r'^fastlane/$', views.fastlane_page, name='fastlane_page'),
+  url(r'^ajax/build/$', views.build_installers, name='ajax-build'),
+  url(r'^ajax/save/$', views.save_state, name='ajax-save'),
+  url(r'^ajax/restore/$', views.restore_state, name='ajax-restore'),
+  url(r'^ajax/reset/$', views.reset_state, name='ajax-reset'),
+  url(r'^ajax/add-user/$', views.add_user, name='ajax-add-user'),
 
 
   # Download pages.
-  
+
   # This pattern matches against the end portion of a URL with a valid build
   # ID (as specified by custominstallerbuilder.common.constants.BUILD_ID_REGEX)
   # followed by a slash.
   #   Example: http://example.com/custominstallerbuilder/28d0ccc35d16fc9114f47f251968b3354183544c/
-  url(r'^(?P<build_id>' + constants.BUILD_ID_REGEX + ')/$', 'download_installers_page', name='download-installers-page'),
+  url(r'^(?P<build_id>' + constants.BUILD_ID_REGEX + ')/$',
+      views.download_installers_page, name='download-installers-page'),
 
   # This pattern extends the one above by appending 'keys/' to the URL.
-  url(r'^(?P<build_id>' + constants.BUILD_ID_REGEX + ')/keys/$', 'download_keys_page', name='download-keys-page'),
-  
+  url(r'^(?P<build_id>' + constants.BUILD_ID_REGEX + ')/keys/$',
+      views.download_keys_page, name='download-keys-page'),
+
   # This pattern extends the one above by further matching against a build ID
   # and two lowercase alphabetic strings, each followed by a slash.
   #   Example: http://example.com/custominstallerbuilder/28d0ccc35d16fc9114f47f251968b3354183544c/foo/bar/
-  url(r'^(?P<build_id>' + constants.BUILD_ID_REGEX + ')/installers/(?P<platform>[a-z]+)/$',
-       'download_installer', name='download-installer'),
-  url(r'^(?P<build_id>' + constants.BUILD_ID_REGEX + ')/keys/(?P<key_type>[a-z]+)/$',
-       'download_keys', name='download-keys'),
-)
+  url(r'^(?P<build_id>' +
+      constants.BUILD_ID_REGEX + ')/installers/(?P<platform>[a-z]+)/$',
+      views.download_installer, name='download-installer'),
+  url(r'^(?P<build_id>' +
+      constants.BUILD_ID_REGEX + ')/keys/(?P<key_type>[a-z]+)/$',
+      views.download_keys, name='download-keys'),
+]

--- a/html/views.py
+++ b/html/views.py
@@ -29,8 +29,7 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponse, HttpResponseRedirect, \
     FileResponse
-from django.shortcuts import render_to_response
-from django.template import RequestContext
+from django.shortcuts import render
 
 import custominstallerbuilder.common.constants as constants
 import custominstallerbuilder.common.packager as packager
@@ -177,9 +176,9 @@ def save_state(request):
   """
   if 'build_string' not in request.POST:
     return ErrorResponse('Unable to save configuration.')
-    
+
   request.session['build_string'] = request.POST['build_string']
-    
+
   return TextResponse()
 
 
@@ -389,12 +388,10 @@ def builder_page(request):
   <Returns>
     A Django response.
   """
-  return render_to_response('builder.html',
-    {
-      'step': 'build',
-    },
-    context_instance=RequestContext(request),
-  )
+  return render(request, 'builder.html',
+      {
+        'step': 'build',
+      })
 
 
 
@@ -435,15 +432,13 @@ def download_keys_page(request, build_id):
       has_private_keys = True
       break
 
-  return render_to_response('download_keys.html',
-    {
-      'build_id': build_id,
-      'has_private_keys': has_private_keys,
-      'keys_downloaded': keys_downloaded,
-      'step': 'keys',
-    },
-    context_instance=RequestContext(request)
-  )
+  return render(request, 'download_keys.html',
+      {
+        'build_id': build_id,
+        'has_private_keys': has_private_keys,
+        'keys_downloaded': keys_downloaded,
+        'step': 'keys',
+      })
 
 
 
@@ -467,7 +462,7 @@ def download_installers_page(request, build_id):
   """
 
   manager = BuildManager(build_id=build_id)
-	
+
   # Invalid build IDs should results in an error.
   if not os.path.isdir(manager.get_build_directory()):
     raise Http404
@@ -494,16 +489,14 @@ def download_installers_page(request, build_id):
       if 'fast_lane_build' in request.session['build_results'][build_id]:
         step = False
 
-  return render_to_response('download_installers.html',
-    {
-      'build_id': build_id,
-      'installers': installer_links,
-      'share_url': share_url,
-      'step': step,
-      'user_built': user_built,
-    },
-    context_instance=RequestContext(request)
-  )
+  return render(request, 'download_installers.html',
+      {
+        'build_id': build_id,
+        'installers': installer_links,
+        'share_url': share_url,
+        'step': step,
+        'user_built': user_built,
+      })
 
 
 
@@ -605,13 +598,13 @@ def fastlane_page(request):
       args=[build_id]))
 
 
-  return render_to_response('download_installers.html', {
+  return render(request, 'download_installers.html', {
       'fast_lane': True,
       'build_id': build_id,
       'installers': installer_links,
       'share_url': share_url,
       'keys_downloaded': keys_downloaded,
-    }, context_instance=RequestContext(request))
+    })
 
 
 
@@ -634,5 +627,7 @@ def error_page(request):
   
   # Automatically choose the email address of the first administrator given
   # in the settings file.
-  return render_to_response('error.html', {'email': settings.ADMINS[0][1]},
-                            context_instance=RequestContext(request))
+  return render(request, 'error.html',
+      {
+        'email': settings.ADMINS[0][1]
+      })

--- a/html/views.py
+++ b/html/views.py
@@ -91,10 +91,10 @@ def require_post(function):
 ######################
 
 def TextResponse(message=''):
-  return HttpResponse(message, mimetype='text/plain')
+  return HttpResponse(message, content_type='text/plain')
 
 def ErrorResponse(message=''):
-  return HttpResponse(message, status=500, mimetype='text/plain')
+  return HttpResponse(message, status=500, content_type='text/plain')
 
 
 

--- a/html/views.py
+++ b/html/views.py
@@ -137,8 +137,8 @@ def build_installers(request):
   try:
     manager = BuildManager(vessel_list=build_data['vessels'], user_data=user_data)
     build_results = manager.prepare()
-  except validations.ValidationError, e:
-    return ErrorResponse(e.message)
+  except validations.ValidationError as e:
+    return ErrorResponse(e)
   except:
     log_exception(request)
     return ErrorResponse('Unknown error occured while trying to build the installers.')
@@ -271,8 +271,8 @@ def add_user(request):
     if public_key is not None:
       validations.validate_public_key(public_key)
         
-  except validations.ValidationError, e:
-    return ErrorResponse(e.message)
+  except validations.ValidationError as e:
+    return ErrorResponse(e)
   except:
     log_exception(request)
     return ErrorResponse('Unknown error occured while trying to add user.')

--- a/html/views.py
+++ b/html/views.py
@@ -26,9 +26,9 @@ except ImportError:
   import json
 
 from django.conf import settings
-from django.core.servers.basehttp import FileWrapper
 from django.core.urlresolvers import reverse
-from django.http import Http404, HttpResponse, HttpResponseRedirect
+from django.http import Http404, HttpResponse, HttpResponseRedirect, \
+    FileResponse
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 
@@ -352,7 +352,9 @@ def download_keys(request, build_id, key_type):
   # Generally, it is undesirable to serve files directly through django, but
   # the key bundles should be very small and still download quickly.
   bundle_filename = key_filenames[key_type]
-  response = HttpResponse(FileWrapper(file(bundle_filename)), content_type='application/zip')
+  # FileResponse is a subclass of StreamingHttpResponse optimized
+  # for binary files requires  Django >1.8
+  response = FileResponse(open(bundle_filename), content_type='application/zip')
   response['Content-Disposition'] = 'attachment; filename=' + os.path.split(bundle_filename)[1]
   response['Content-Length'] = os.path.getsize(bundle_filename)
   

--- a/local/settings.py
+++ b/local/settings.py
@@ -28,7 +28,6 @@ SECRET_KEY = '***** This should be changed to a random string *****'
 
 # Unless you are actively debugging, these should be set to False.
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 
 # During testing, you may want to use Django's built-in static file server.
 SERVE_STATIC = False
@@ -45,3 +44,7 @@ MEDIA_URL = PROJECT_URL + 'static/'
 
 # The locations of the customized installers created by this program.
 CUSTOM_INSTALLER_URL = PROJECT_URL + 'static/installers/'
+
+# If you set DEBUG to False, you also need to properly set the ALLOWED_HOSTS
+# setting, eg.:
+# ALLOWED_HOSTS = ["example.com"]

--- a/settings_base.py
+++ b/settings_base.py
@@ -25,26 +25,39 @@ LANGUAGE_CODE = 'en-us'
 
 ROOT_URLCONF = 'custominstallerbuilder.urls'
 
-TEMPLATE_CONTEXT_PROCESSORS = (
-  'django.core.context_processors.debug',
-  'django.core.context_processors.media',
-  'django.core.context_processors.request',
-)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                # Adds 'debug' and 'sql_queries' to template context
+                #'django.template.context_processors.debug',
+                # Adds 'LANGUAGES' and 'LANGUAGE_CODE' to template context
+                # 'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                # Adds 'STATIC_URL' to template context
+                # 'django.template.context_processors.static',
+                # Adds 'TIME_ZONE' to template context
+                # 'django.template.context_processors.tz',
+                # Adds 'request' to template context
+                # 'django.template.context_processors.request',
+                # Adds 'messages' and 'DEFAULT_MESSAGE_LEVELS' to context
+                #'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
 
-TEMPLATE_LOADERS = (
-  'django.template.loaders.app_directories.Loader',
-)
 
 MIDDLEWARE_CLASSES = (
   'django.middleware.common.CommonMiddleware',
   'django.contrib.sessions.middleware.SessionMiddleware',
-  
   'custominstallerbuilder.common.logging.AutoLogger',
 )
 
 INSTALLED_APPS = (
   'django.contrib.sessions',
-  
   'custominstallerbuilder.common',
   'custominstallerbuilder.html',
   'custominstallerbuilder.xmlrpc',
@@ -103,7 +116,6 @@ RESERVED_PUBLIC_KEY = ('22599311712094481841033180665237806588790054310631' +
 
 # Unless you are actively debugging, these should be set to False.
 DEBUG = False
-TEMPLATE_DEBUG = DEBUG
 
 SECRET_KEY = '***** This should be changed to a random string *****'
 

--- a/urls.py
+++ b/urls.py
@@ -14,14 +14,14 @@
   initiates a static file server if local settings call for it.
 """
 
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 from django.conf import settings
-
+from django.views.static import serve
 
 # Display errors gracefully.
 handler500 = 'custominstallerbuilder.html.views.error_page'
 
-urlpatterns = patterns('',
+urlpatterns = [
   # XML-RPC URL patterns. Matches all URLs which start with 'xmlrpc' followed
   # by a slash.
   #   Example: http://example.com/custominstallerbuilder/xmlrpc/[...]
@@ -32,18 +32,19 @@ urlpatterns = patterns('',
   #   Example: http://example.com/custominstallerbuilder/
   #        or  http://example.com/custominstallerbuilder/ajax/build/
   url(r'', include('custominstallerbuilder.html.urls')),
-)
+]
 
 # Use the 'SERVE_STATIC' and 'STATIC_BASE' custom settings to determine if
 # Django should serve static files itself. This is useful for debugging.
 if getattr(settings, 'SERVE_STATIC', False):
-  
+
   # Matches URLs which start with the contents of STATIC_BASE as specified in
   # settings.py, followed by a slash then any string. That string is
   # interpreted as a path for a file to lookup.
   #   Example: http://example.com/custominstallerbuilder/static/[...]
   regex = r'^%s/(?P<path>.*)$' % settings.STATIC_BASE.rstrip('/')
-  
-  urlpatterns += patterns('',
-    url(regex, 'django.views.static.serve', {'document_root': settings.MEDIA_ROOT, 'show_indexes': settings.DEBUG}),
-  )
+
+  urlpatterns += [
+    url(regex, serve,
+        {'document_root': settings.MEDIA_ROOT, 'show_indexes': settings.DEBUG}),
+  ]

--- a/xmlrpc/urls.py
+++ b/xmlrpc/urls.py
@@ -13,15 +13,17 @@
   Custom Installer Builder.
 """
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
+import custominstallerbuilder.xmlrpc.views as views
+
 
 
 # Note: All URLs that have been delegated to these patterns have already
 # matched the '^xmlrpc/' prefix. These patterns test against the rest of the
 # URL string.
 
-urlpatterns = patterns('',
+urlpatterns = [
   # Matches the empty string.
   #   Example: http://example.com/custominstallerbuilder/xmlrpc/
-  url(r'^$', 'custominstallerbuilder.xmlrpc.views.xmlrpc_handler', name='xmlrpc-handler'),
-)
+  url(r'^$', views.xmlrpc_handler, name='xmlrpc-handler'),
+]

--- a/xmlrpc/views.py
+++ b/xmlrpc/views.py
@@ -21,8 +21,7 @@
 from SimpleXMLRPCServer import CGIXMLRPCRequestHandler
 
 from django.http import HttpResponse
-from django.shortcuts import render_to_response
-from django.template import RequestContext
+from django.shortcuts import render
 
 from custominstallerbuilder.xmlrpc.functions import PublicFunctions
 
@@ -46,16 +45,16 @@ def xmlrpc_handler(request):
   <Returns>
     A Django HTTP response.
   """
-  
+
   if request.method == 'GET':
-    response = render_to_response('xmlrpc-info.html', context_instance=RequestContext(request))    
+    response = render(request, 'xmlrpc-info.html')
 
   elif request.method == 'POST':
     # Not all languages have the notion of "None".
     xmlrpc_handler = CGIXMLRPCRequestHandler(allow_none=False, encoding=None)
     xmlrpc_handler.register_instance(PublicFunctions())
-  
+
     response = HttpResponse(content_type='application/xml')
     response.write(xmlrpc_handler._marshaled_dispatch(request.body))
-    
+
   return response

--- a/xmlrpc/views.py
+++ b/xmlrpc/views.py
@@ -55,7 +55,7 @@ def xmlrpc_handler(request):
     xmlrpc_handler = CGIXMLRPCRequestHandler(allow_none=False, encoding=None)
     xmlrpc_handler.register_instance(PublicFunctions())
   
-    response = HttpResponse(mimetype='application/xml')
+    response = HttpResponse(content_type='application/xml')
     response.write(xmlrpc_handler._marshaled_dispatch(request.body))
     
   return response


### PR DESCRIPTION
This PR tackles all Django Deprecation Warnings I found in my log when clicking through a test instance of CustomInstallerBuilder. See commit messages for details.

I tested running `python manage.py runserver` and browsing localhost as well as running the test scripts in `custominstallerbuilder/tests` on Django 1.8, 1.9 and 1.10.

A few notes on testing:
The script `example_stress_test.py` seems to be broken (a very brief search suggested that it might be related to threading on OS X). The scripts `test_build_installers.py` and `test_invalid_input.py` had to be monkey patched because they import `integrationtestlib` and `send_gmail` which I don't know where from. Apart from that everything worked fine on Django 1.8.
On Django 1.9. and 1.10 Seattle's namespace patching (`safe_type`) conflicts with the development server's django setup.
For 1.9 one can bypass the problem by running `python manage.py runserver --no-threading`. For 1.10. we have to actually fix the problem.
We should also check if the problem persists when running on a development server (e.g. Apache).
